### PR TITLE
update gradle.build to build the entire jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ConfigTool/ConfigTool.iml
 # Gradle ignores
 .gradle
 /build/
+/bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -19,3 +20,8 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+# Ignore Eclipse
+.classpath
+.project
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,34 @@
 
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
-ant.importBuild 'ConfigTool/build.xml'
+version = '1.0.3'
 
 sourceSets {
     main {
         java {
             srcDir 'ConfigTool/src'
         }
+        resources {
+            srcDir 'ConfigTool/src'
+            exclude '**/*.java'
+        }
+    }
+}
+
+jar {
+	manifest {
+	    attributes 'Main-Class': 'org.hyperion.hypercon.Main',
+	               'Specification-Title': 'HyperCon',
+	               'Specification-Version': version,
+	               'Specification-Vendor': 'Hyperion Team',
+	               'Implementation-Title': 'org.hyperion',
+	               'Implementation-Version': version,
+	               'Implementation-Vendor': 'Hyperion Team'
+	}
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }
 


### PR DESCRIPTION
Not sure if there is a specific reason to use ant, but this simplifies the build by not even needing it.

gradle can build the entire jar so why not just do it that way.

This make the default jar from gradle a "fatjar" that includes all the needed dependencies.

the ant build.xml could be removed in this case.