### PR TITLE
add LibreELEC specific support

### DIFF
--- a/ConfigTool/src/org/hyperion/hypercon/spec/HyperionRemoteCalls.java
+++ b/ConfigTool/src/org/hyperion/hypercon/spec/HyperionRemoteCalls.java
@@ -11,7 +11,8 @@ public final class HyperionRemoteCalls {
 
     public enum SystemTypes{
         allsystems(language.getString("ssh.systemlist.allsystemsitem")),
-        openelec("OpenELEC / LE");
+        libreelec("LibreELEC"),
+        openelec("OpenELEC");
 
         private final String text;
 
@@ -27,6 +28,8 @@ public final class HyperionRemoteCalls {
     public static String getHyperionRemoteCallForSystemType(SystemTypes type){
         if(type == SystemTypes.allsystems){
             return "hyperion-remote ";
+        }else if(type == SystemTypes.libreelec){
+            return "/storage/.kodi/addons/service.hyperion/bin/hyperion-remote ";
         }else if(type == SystemTypes.openelec){
             return "/storage/hyperion/bin/hyperion-remote.sh ";
         }
@@ -36,6 +39,8 @@ public final class HyperionRemoteCalls {
     public static String getGrabberv4l2CallForSystemType(SystemTypes type){
         if(type == SystemTypes.allsystems){
             return "hyperion-v4l2 ";
+        }else if(type == SystemTypes.libreelec){
+            return "/storage/.kodi/addons/service.hyperion/bin/hyperion-v4l2 ";
         }else if(type == SystemTypes.openelec){
             return "/storage/hyperion/bin/hyperion-v4l2.sh ";
         }
@@ -44,6 +49,8 @@ public final class HyperionRemoteCalls {
     public static String getConfigTargetCallForSystemType(SystemTypes type){
         if(type == SystemTypes.allsystems){
             return "/etc/hyperion/";
+        }else if(type == SystemTypes.libreelec){
+            return "/storage/.kodi/userdata/addon_data/service.hyperion/";
         }else if(type == SystemTypes.openelec){
             return "/storage/.config/";
         }
@@ -69,6 +76,8 @@ public final class HyperionRemoteCalls {
     public static String getHyperionStartServiceCallForSystemType(SystemTypes type){
         if(type == SystemTypes.allsystems){
             return "sudo systemctl start hyperion.service 2>/dev/null ; sudo /etc/init.d/hyperion start 2>/dev/null ; sudo /sbin/initctl start hyperion 2>/dev/null";
+        }else if(type == SystemTypes.libreelec){
+            return "systemctl start service.hyperion.service 2>/dev/null";
         }else if(type == SystemTypes.openelec){
             return "/storage/.config/autostart.sh > /dev/null 2>&1 &";
         }
@@ -77,6 +86,8 @@ public final class HyperionRemoteCalls {
     public static String getHyperionStopServiceCallForSystemType(SystemTypes type){
         if(type == SystemTypes.allsystems){
             return "sudo systemctl stop hyperion.service 2>/dev/null; sudo /etc/init.d/hyperion stop 2>/dev/null ; sudo /sbin/initctl stop hyperion 2>/dev/null";
+        }else if(type == SystemTypes.libreelec){
+            return "systemctl stop service.hyperion.service 2>/dev/null";
         }else if(type == SystemTypes.openelec){
             return "killall hyperiond 2>/dev/null";
         }
@@ -85,6 +96,8 @@ public final class HyperionRemoteCalls {
     public static String getHyperionLogCallForSystemType(SystemTypes type){
         if(type == SystemTypes.allsystems){
             return "sudo journalctl -u hyperion.service 2>/dev/null";
+        }else if(type == SystemTypes.libreelec){
+            return "journalctl -u service.hyperion.service 2>/dev/null";
         }else if(type == SystemTypes.openelec){
             return "cat /storage/logfiles/hyperion.log";
         }

--- a/ConfigTool/src/org/hyperion/hypercon/spec/MiscConfig.java
+++ b/ConfigTool/src/org/hyperion/hypercon/spec/MiscConfig.java
@@ -19,6 +19,7 @@ public class MiscConfig {
 //Effect Engine
 	/** declare all paths **/
 	public String mPathOE = "/storage/hyperion/effects" ;
+	public String mPathLE = "/storage/.kodi/addons/service.hyperion/effects" ;
 	public String mPathGEN = "/usr/share/hyperion/effects" ;
 	/** Flag indicating that the boot sequence is enabled(true) or not(false) */
 	public boolean mBootEffectEnabled = true;
@@ -219,6 +220,7 @@ public class MiscConfig {
 			strBuf.startObject("effects");
 			strBuf.startArray("paths");
 			strBuf.addPathValue(mPathOE, false);
+			strBuf.addPathValue(mPathLE, false);
 			strBuf.addPathValue(mPathGEN, true);
 			strBuf.stopArray(true);
 			strBuf.stopObject();


### PR DESCRIPTION
This treats OpenELEC and LibreELEC as different systems

We have hyperion available in our add-on repository so we can use that. I have added a specific LibreELEC system that will use the paths that are used for the add-on.

If I missed anything please let me know.