### PR TITLE
also kill 'hyperion-x11' processes

### DIFF
--- a/ConfigTool/src/org/hyperion/hypercon/spec/HyperionRemoteCalls.java
+++ b/ConfigTool/src/org/hyperion/hypercon/spec/HyperionRemoteCalls.java
@@ -78,7 +78,7 @@ public final class HyperionRemoteCalls {
         if(type == SystemTypes.allsystems){
             return "sudo systemctl stop hyperion.service 2>/dev/null; sudo /etc/init.d/hyperion stop 2>/dev/null ; sudo /sbin/initctl stop hyperion 2>/dev/null";
         }else if(type == SystemTypes.openelec){
-            return "killall hyperiond 2>/dev/null";
+            return "killall hyperiond 2>/dev/null; killall hyperion-x11 2>/dev/null";
         }
         return "";
     }


### PR DESCRIPTION
1. Tell us something about your changes.
On my target platform there are multiple hyperion-x11 processes and after a few restarts the led strip starts to flicker. The install and remove script should also kill these processes
2. If this changes affect the .conf file. Please provide the changed section
No changes in the .conf file
3. Reference a issue (optional)
No open issue for this change